### PR TITLE
Minor fixes on people and project pages

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -171,6 +171,8 @@ people:
       interests: "Security in operating systems and full stack networking. Distributed software and version control systems"
       projects:
         - *in-toto
+        - *tuf
+        - *uptane
         - *seattle
         - *sensibility
       publications:
@@ -479,6 +481,7 @@ people:
       projects:
         - *uptane
         - *tuf
+        - *in-toto
 
   - joey_pabalinas: &joey_pabalinas
       name: "Joey Pabalinas"
@@ -487,7 +490,7 @@ people:
       internal: true
       role: "Developer"
       since: 2018
-      photo: "img/people/joey_pabalinas"
+      photo: "img/people/joey_pabalinas.jpg"
       interests: "Linux kernel development"
       projects:
       - *crashsimulator

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -83,11 +83,11 @@ companies</a>, including <a href=\"https://docs.microsoft.com/en-us/azure/contai
     projects as part of the Cloud Native Computing Foundation.  
 <a href=\"https://store.cncf.io/collections/tuf\">Buy our merch!</a>"
       people:
-
         - *sebastien_awwad
         - *marina_moore
         - *trishank_kuppusamy
         - *vlad_diaz
+        - *lukas_puhringer
         - *justin_cappos
       tags:
       - *software_updates
@@ -141,6 +141,7 @@ demo video</a> is available."
         - *sebastien_awwad
         - *marina_moore
         - *lois_delong
+        - *lukas_puhringer
         - name: Ira McDonald (High North Inc.)
           link: 
         - name: Cameron Mott (SWRI)
@@ -341,7 +342,6 @@ some computing power on their device for research purposes."
   - sensibility: &sensibility
       name: "Sensibility Testbed"
       anchor: "sensibility"
-      image: "https://sensibilitytestbed.com/projects/project/chrome/site/sense.jpg"
       status: *retired
       site: "https://sensibilitytestbed.com/"
       description: "Given the close proximity of smartphones to users,
@@ -355,11 +355,12 @@ or learn more by <a href=\"https://seattlesensor.wordpress.com/\">visiting our p
       people:
         - *albert_rafetseder
         - *yanyan_zhuang
-        - *yu_hu
+        - name: "Yu Hu"
         - name: "Richard Weiss"
           link: "http://evergreen.edu/directory/people/weissr"
         - name: "Leon Reznik"
           link: "https://www.cs.rit.edu/people/faculty/lr"
+        - *lukas_puhringer
         - *justin_cappos
       tags:
         - *testbeds


### PR DESCRIPTION
- Update project-people affiliation for lukas
- Fix link to joey's picture
- Remove dead link to sensibility project image
- Replace reference to yu's person card (was removed) with his
  hardcoded name on the sensibility project card.