### PR TITLE
removed Cook and Roongta

### DIFF
--- a/_data/data.yml
+++ b/_data/data.yml
@@ -636,8 +636,6 @@ people:
           - *marina_moore
           - *nick_renner
           - *aditya_sirish
-          - *ritik_roongta
-          - *jack_cook
           
       - type: "Other Students"
         anchor: otherstudents


### PR DESCRIPTION
Per Justin's directions, I removed Jack and Ritik from the Ph.D. page. I'll be adding two more shortly. I'm waiting for information and photos.