### PR TITLE
Add TAF to projects

### DIFF
--- a/_data/data.yml
+++ b/_data/data.yml
@@ -917,6 +917,24 @@ projects:
         tags:
             - *security
 
+    - &taf
+        name: "The Archive Framework (TAF)"
+        anchor: "taf"
+        status: *starting
+        site:
+        description: "Built on top of The Update Framework (TUF), TAF leverages TUF's security capabilities to protect Git repositories and provide archival authentication. Primarily applied in the legal field, it aims to enable government institutions to secure their entire legal supply chain and meet the standards for authentication and preservation set forth in The Uniform Electronic Legal Materials Act. Additionally, a key objective of TAF is to ensure that documents stored in Git repositories remain accessible and verifiable, not just in the immediate future, but for decades and even centuries to come."
+        products: "TAF is already being used by several governments, including the District of Columbia, to secure their laws, and by two libraries, including the University of Wisconsin Law Library. The D.C. law library, secured with TAF, is publically accessible on <a href=\"https://github.com/DCCouncil\">GitHub</a>."
+        people:
+            - name: "Renata Vaderna (Open Law Library)"
+              link: "https://github.com/renatav"
+            - name: "Dusan Nikolic (Open Law Library)"
+              link: "https://github.com/n-dusan"
+            - name: "David Greisen (Open Law Library)"
+              link: "https://github.com/dgreisen"
+            - *justin_cappos
+        tags:
+            - *security
+
     - &atoms
         name: "Atoms of Confusion"
         anchor: "atoms"
@@ -1211,6 +1229,7 @@ projects:
     - *uptane
     - *in-toto
     - *gittuf
+    - *taf
     - *cachecash
     - *lind
     - *atoms


### PR DESCRIPTION
Include TAF in the list of projects, emphasizing the ongoing work funded by the NSF grant.

Doesn't look like CI is run on PRs, but I managed to run the server locally and there were no errors. Looks good to me:

![image](https://github.com/secure-systems-lab/ssl-site/assets/5716827/544b7760-7071-4918-813b-234e47085914)
